### PR TITLE
fix: issues with LoginDetailOidcService

### DIFF
--- a/src/main/java/com/zedapps/bookshare/service/auth/LoginDetailOidcService.java
+++ b/src/main/java/com/zedapps/bookshare/service/auth/LoginDetailOidcService.java
@@ -4,6 +4,7 @@ import com.zedapps.bookshare.entity.login.Login;
 import com.zedapps.bookshare.enums.AuthProvider;
 import com.zedapps.bookshare.enums.Role;
 import com.zedapps.bookshare.repository.login.LoginRepository;
+import com.zedapps.bookshare.util.Utils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -49,11 +50,12 @@ public class LoginDetailOidcService implements OAuth2UserService<OidcUserRequest
             login.setEmail(email);
             login.setFirstName(firstName);
             login.setLastName(lastName);
-            login.setHandle(firstName + "." + lastName + "." + UUID.randomUUID().toString().substring(0, 4));
+            login.setHandle(email.split("@")[0] + "." + UUID.randomUUID().toString().substring(0, 4));
             login.setRole(Role.USER);
             login.setAuthProvider(AuthProvider.GOOGLE);
             login.setProviderId(providerId);
             login.setActive(true);
+            login.getShelves().addAll(Utils.getDefaultShelves(login));
 
             login = loginRepository.save(login);
         }

--- a/src/main/java/com/zedapps/bookshare/service/login/LoginService.java
+++ b/src/main/java/com/zedapps/bookshare/service/login/LoginService.java
@@ -10,6 +10,7 @@ import com.zedapps.bookshare.repository.image.ImageRepository;
 import com.zedapps.bookshare.repository.login.LoginRepository;
 import com.zedapps.bookshare.service.activity.ActivityService;
 import com.zedapps.bookshare.service.auth.LoginDetails;
+import com.zedapps.bookshare.util.Utils;
 import jakarta.persistence.NoResultException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -152,13 +153,7 @@ public class LoginService {
     }
 
     private void setupShelvesForNewLogin(Login login) {
-        Shelf.DEFAULT_SHELF_NAMES.forEach(shelfName -> {
-            Shelf shelf = new Shelf();
-            shelf.setName(shelfName);
-            shelf.setUser(login);
-            shelf.setDefaultShelf(true);
-
-            login.getShelves().add(shelf);
-        });
+        List<Shelf> defaultShelves = Utils.getDefaultShelves(login);
+        login.getShelves().addAll(defaultShelves);
     }
 }

--- a/src/main/java/com/zedapps/bookshare/util/Utils.java
+++ b/src/main/java/com/zedapps/bookshare/util/Utils.java
@@ -2,6 +2,8 @@ package com.zedapps.bookshare.util;
 
 import com.zedapps.bookshare.dto.api.ErrorResponseDto;
 import com.zedapps.bookshare.entity.image.Image;
+import com.zedapps.bookshare.entity.login.Login;
+import com.zedapps.bookshare.entity.login.Shelf;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -9,6 +11,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -30,6 +33,19 @@ public class Utils {
                   .buildAndExpand(image.getId())
                   .toUriString()
                 : "";
+    }
+
+    public static List<Shelf> getDefaultShelves(Login login) {
+        return Shelf.DEFAULT_SHELF_NAMES.stream()
+                .map(shelfName -> {
+                    Shelf shelf = new Shelf();
+                    shelf.setName(shelfName);
+                    shelf.setUser(login);
+                    shelf.setDefaultShelf(true);
+
+                    return shelf;
+
+                }).toList();
     }
 
     public static String cleanHtml(String htmlText) {


### PR DESCRIPTION
When a user registered using OAuth login, two issues existed that caused new users to face issues when navigating across the application.

The creation of user did not involve creating default shelves, that is understood as a default flow of registration. This failed the profile to be opened, and book pages to fail, as default shelves did not exist.

Also, when creating the user, the user's first name and last names are joined to create the handle. While this is fine in most cases, users that have spaces or special characters in their name would pose an issue. As such, the first part of the email address - i.e. the actual user name, stripped from the domain - is considered when generating the handle.